### PR TITLE
refactor(SerialIO): moved port preparation to `open()`

### DIFF
--- a/lib/SerialIO.js
+++ b/lib/SerialIO.js
@@ -16,47 +16,12 @@ class SerialIO {
     this.d('initializing SerialIO on port: %s', port)
     this._sp = sp
     this._portString = port
-    this._port = new this._sp(port, { autoOpen: false })
-    this._parser = new DataParser()
-    this._parser.onMessage((msg) => this._handleMessage(msg))
-    this._port.on('data', (data) => {
-      try {
-        this._parser.parseData(data)
-      } catch (e) {
-        this.d('parsing data failed: %s', e.message || e)
-      }
-    })
-    this._port.on('error', (err) => {
-      this.d('error event: %s', err)
-      if (this._onErrorHandler) {
-        try {
-          this._onErrorHandler(err)
-        } catch (e) {
-          this.d('error handler returned with error: %s', e.message || e)
-        }
-      }
-    })
-    this._port.on('drain', (err) => {
-      this.d('drain event: %s', err)
-      if (this._onDrainHandler) {
-        try {
-          this._onDrainHandler(err)
-        } catch (e) {
-          this.d('drain handler returned with error: %s', e.message || e)
-        }
-      }
-    })
 
-    this._port.on('open', (err) => {
-      this.d('open event: %s', err)
-      if (this._onOpenHandler) {
-        try {
-          this._onOpenHandler(err)
-        } catch (e) {
-          this.d('open handler returned with error: %s', e.message || e)
-        }
-      }
-    })
+    /**
+     * Indicates if a message transaction is in progress
+     * @type {boolean}
+     */
+    this.sending = false
 
     /**
      * indicates if closing event is intended behaviour
@@ -64,13 +29,52 @@ class SerialIO {
      * @private
      */
     this._closing = false
-    this._port.on('close', err => this._closeHandler(new Error(err)))
 
     /**
-     * Indicates if a message transaction is already in progress
-     * @type {boolean}
+     * Holds event handlers
+     * @type {Object.<string, function>}
+     * @private
      */
-    this.sending = false
+    this._handlers = {}
+  }
+
+  /**
+   * Prepares the serialport (without opening it). May throw an error, if the target port does not exist
+   */
+  preparePort () {
+    this._port = new this._sp(this._portString, { autoOpen: false })
+    this._parser = new DataParser()
+    this._parser.onMessage((msg) => this._handleMessage(msg))
+    this._port.on('data', data => {
+      try { this._parser.parseData(data) } catch (e) { this.d('parsing data failed: %s', e.message || e) }
+    })
+    this._port.on('error', err => {
+      this.d('error event: %s', err)
+      if (this._handlers.error) {
+        try { this._handlers.error(err) } catch (e) { this.d('error handler returned with error: %s', e.message || e) }
+      }
+    })
+    this._port.on('drain', err => {
+      this.d('drain event: %s', err)
+      if (this._handlers.drain) {
+        try { this._handlers.drain(err) } catch (e) { this.d('drain handler returned with error: %s', e.message || e) }
+      }
+    })
+
+    this._port.on('open', err => {
+      this.d('open event: %s', err)
+      if (this._handlers.open) {
+        try { this._handlers.open(err) } catch (e) { this.d('open handler returned with error: %s', e.message || e) }
+      }
+    })
+    this._port.on('close', err => {
+      this.d('close event: %s', err)
+      if (this._handlers.close) {
+        // provide handler with additional 'unexpected' flag
+        try { this._handlers.close(err, !this._closing) } catch (e) { this.d('close handler returned with error: %s', e.message || e) }
+      }
+      this._closeHandler(new Error(err))
+    })
   }
 
   /**
@@ -102,12 +106,19 @@ class SerialIO {
   open () {
     this._closing = false
     return new Promise((resolve, reject) => {
-      this._port.open((err) => {
-        if (err === null) {
-          resolve()
-        } else {
-          reject(err)
+      // check if port needs to be prepared first
+      if (!this._port) {
+        try {
+          this.preparePort()
+        } catch (e) {
+          this.d('preparing port failed: %s', e.message || e)
+          reject(e)
+          return
         }
+      }
+
+      this._port.open((e) => {
+        if (e === null) { resolve() } else { this.d('opening port failed: %s', e.message || e); reject(e) }
       })
     })
   }
@@ -120,11 +131,7 @@ class SerialIO {
     this._closing = true
     return new Promise((resolve, reject) => {
       this._port.close((err) => {
-        if (err === null) {
-          resolve()
-        } else {
-          reject(err)
-        }
+        if (err === null) { resolve() } else { reject(err) }
       })
     })
   }
@@ -134,6 +141,8 @@ class SerialIO {
    * @returns {boolean}
    */
   isOpen () {
+    if (!this._port) return false
+
     return this._port.isOpen
   }
 
@@ -145,44 +154,71 @@ class SerialIO {
    */
 
   /**
+   * Callback called on each open event
+   *
+   * @callback onOpenHandler
+   */
+
+  /**
+   * Callback called on each close event
+   *
+   * @callback onCloseHandler
+   * @param {Error|undefined} error
+   * @param {boolean} expected - whether or not this close event was expected, i.e. invoked by user
+   */
+
+  /**
+   * Callback called on each drain event
+   *
+   * @callback onDrainHandler
+   * @param {Error|undefined} error
+   */
+
+  /**
+   * Callback called on each error event
+   *
+   * @callback onErrorHandler
+   * @param {Error|undefined} error
+   */
+
+  /**
    * Sets the handler to be called when a new message has been received
    * @param {onMessageHandler} handler
    */
   onMessage (handler) {
-    this._onMessageHandler = handler
-    // this._parser.onMessage(handler)
+    this._handlers.message = handler
   }
 
   /**
    * Sets a handler to be called on 'error' events of the underlying serial port
-   * @param {function} handler
+   * @param {onErrorHandler} handler
    */
   onError (handler) {
-    this._onErrorHandler = handler
+    this._handlers.error = handler
   }
 
   /**
    * Sets a handler to be called on 'drain' events of the underlying serial port
-   * @param {function} handler
+   * @param {onDrainHandler} handler
    */
   onDrain (handler) {
-    this._onDrainHandler = handler
+    this._handlers.drain = handler
   }
 
   /**
    * Sets a handler to be called on 'close' events of the underlying serial port
-   * @param {function} handler
+   * @param {onCloseHandler} handler
    */
   onClose (handler) {
-    this._onCloseHandler = handler
+    this._handlers.close = handler
   }
 
   /**
    * Sets a handler to be called on 'open' events of the underlying serial port
-   * @param {function} handler
+   * @param {onOpenHandler} handler
    */
   onOpen (handler) {
-    this._onOpenHandler = handler
+    this._handlers.open = handler
   }
 
   /**
@@ -316,32 +352,26 @@ class SerialIO {
         }
       } else {
         // check if there is a message handler for this type
-        if (this._onMessageHandler) {
+        if (this._handlers.message) {
           (async () => {
             try {
-              let reply = this._onMessageHandler(parsedMsg || rawString)
-              if (reply instanceof Promise) {
-                this.d('message handler returned Promise. Awating reply...')
-                reply = await reply
-              }
+              let reply = await this._handlers.message(parsedMsg || rawString)
               this.d('message handler returned with reply')
-              try {
-                await this.sendReply(reply)
-              } catch (e) {
-                this.d('sending reply failed: %s', e.message || e)
-              }
+              this.sendReply(reply).catch(
+                e => this.d('sending reply failed: %s', e.message || e)
+              )
             } catch (e) {
               this.d('error while calling message handler')
-              this.sendErrorReply(e).catch((err) => {
-                this.d('sending message handler error as reply failed: %s', err.message || err)
-              })
+              this.sendErrorReply(e).catch(
+                (err) => this.d('sending message handler error as reply failed: %s', err.message || err)
+              )
             }
           })()
         } else {
           this.d('No message handler to handle message')
-          this.sendErrorReply('No message handler to handle message').catch((err) => {
+          this.sendErrorReply('No message handler to handle message').catch((err) =>
             this.d('sending missing message handler error as reply failed: %s', err.message || err)
-          })
+          )
         }
       }
     } catch (e) {
@@ -355,14 +385,6 @@ class SerialIO {
    * @private
    */
   _closeHandler (err) {
-    // provide handler with additional 'unexpected' flag
-    if (this._onCloseHandler) {
-      try {
-        this._onCloseHandler(err, !this._closing)
-      } catch (e) {
-        this.d('close handler returned with error: %s', err.message || err)
-      }
-    }
     if (!this._closing) {
       this.d('unexpected closing of port: %s', err.message || err)
       this._reopenAttempts = 0


### PR DESCRIPTION
port preparation and binding has been moved to its own function and is now executed on first `open()`. Also includes bundling of event handlers.